### PR TITLE
Minor Improvements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,3 +2,7 @@
 - include: postfix.yml
 - include: opendkim.yml
   when: mta_dkim | default(False)
+
+- name: update /etc/mailname
+  copy: dest=/etc/mailname content={{ mta_override_hostname | default(inventory_hostname) }}
+        owner=root group=root mode=644

--- a/templates/opendkim/KeyTable
+++ b/templates/opendkim/KeyTable
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
+
 {% if mta_dkim_sign -%}
 {%- for domain in mta_dkim_domains %}
 {{ domain.key }}._domainkey.{{ domain.name }} {{ domain.name }}:{{ domain.key }}:/etc/opendkim/keys/{{ domain.name }}/{{ domain.key }}.private

--- a/templates/opendkim/SigningTable
+++ b/templates/opendkim/SigningTable
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
+
 {% if mta_dkim_sign -%}
 {%- for domain in mta_dkim_domains %}
 *@{{ domain.name }} {{ domain.key }}._domainkey.{{ domain.name }}

--- a/templates/opendkim/opendkim.conf
+++ b/templates/opendkim/opendkim.conf
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
+
 PidFile                 /var/run/opendkim/opendkim.pid
 
 Mode                    {{ 's' if mta_dkim_sign else '' }}{{ 'v' if mta_dkim_verify else '' }}

--- a/templates/postfix/aliases
+++ b/templates/postfix/aliases
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
+
 {% for entry in item.map|dictsort(by='key') %}
 {{ entry[0] }}: {{ entry[1] if entry[1] is string else (entry[1] | join(", ")) }}
 {% endfor %}

--- a/templates/postfix/main.cf
+++ b/templates/postfix/main.cf
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
+
 # configuration
 myhostname = {{ mta_override_hostname | default(inventory_hostname) }}
 myorigin = $myhostname

--- a/templates/postfix/master.cf
+++ b/templates/postfix/master.cf
@@ -1,3 +1,4 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
 #
 # Postfix master process configuration file.  For details on the format
 # of the file, see the master(5) manual page (command: "man 5 master" or

--- a/templates/postfix/password_map
+++ b/templates/postfix/password_map
@@ -1,1 +1,2 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
 {{ mta_relayhost }} {{ mta_relayhost_auth.username }}:{{ mta_relayhost_password }}

--- a/templates/postfix/transport_map
+++ b/templates/postfix/transport_map
@@ -1,4 +1,4 @@
-### Managed by ansible ###
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
 {% for entry in mta_transport_map | dictsort(by='key') %}
 {{ entry[0] }}      {{ entry[1] }}
 {% endfor %}

--- a/templates/postfix/virtual
+++ b/templates/postfix/virtual
@@ -1,3 +1,4 @@
+### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###
 {{ '#' }} virtual table for domain {{ item.domain }}
 {% for entry in item.map|dictsort(by='key') %}
 {{ entry[0] }}@{{ item.domain }} {{ entry[1] if entry[1] is string else (entry[1] | join(", ")) }}


### PR DESCRIPTION
Adds `### THIS FILE IS MANAGED BY ANSIBLE -- DO NOT EDIT! ###` to all of the files.

Sets `/etc/mailname` to `mta_override_hostname` or `inventory_hostname` (if the former is not specified; the same logic is used in posfix's `main.cf`).