### PR TITLE
Extend mta_services logic

### DIFF
--- a/templates/postfix/main.cf
+++ b/templates/postfix/main.cf
@@ -216,3 +216,12 @@ message_size_limit = {{ mta_message_size_limit }}
 # origin: mta_unverified_recipient_reject_code
 unverified_recipient_reject_code = {{ mta_unverified_recipient_reject_code }}
 {% endif %}
+
+{% for service in mta_services %}
+  {% if service.transport_config is defined %}
+# origin: mta_services[{{ service.service }}].transport_config
+    {% for key, value in service.transport_config.items() %}
+{{ service.service }}_{{ key }} = {{ value }}
+    {% endfor %}
+  {% endif %}
+{% endfor %}

--- a/templates/postfix/master.cf
+++ b/templates/postfix/master.cf
@@ -67,7 +67,12 @@ anvil     unix  -       -       n       -       1       anvil
 scache    unix  -       -       n       -       1       scache
 
 {% for service in mta_services %}
-{{ service.port }} {{ service.type }}  n       -       n       -       -       {{ service.command }}
+{{ service.service }} {{ service.type }} {{ service.private | default('-') }} {{ service.unpriv | default('-') }} {{ service.chroot | default('n') }} {{ service.wakeup | default('-') }} {{ service.maxproc | default('-') }} {{ service.command }}
+  {% if service.command_attributes is defined %}
+    {% for key, value in service.command_attributes.items() %}
+  {{ key }}={{ value }}
+    {% endfor %}
+  {% endif %}
   {% if service.options is defined %}
     {% for key, value in service.options.items() %}
       {% if value is sequence and value is not string %}


### PR DESCRIPTION
- Allow to specify command attributes (see `man 8 pipe`).
- Allow to specify transport specific configuration in main.cf.

These changes are meant for a new OTRS role.